### PR TITLE
feat: add custom axis label style formatter

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/components/AxisBase.java
@@ -6,6 +6,7 @@ import android.graphics.DashPathEffect;
 import android.util.Log;
 
 import com.github.mikephil.charting.formatter.DefaultAxisValueFormatter;
+import com.github.mikephil.charting.formatter.IAxisStyleFormatter;
 import com.github.mikephil.charting.formatter.IAxisValueFormatter;
 import com.github.mikephil.charting.utils.Utils;
 
@@ -23,6 +24,8 @@ public abstract class AxisBase extends ComponentBase {
      * custom formatter that is used instead of the auto-formatter if set
      */
     protected IAxisValueFormatter mAxisValueFormatter;
+
+    protected IAxisStyleFormatter mAxisLabelStyleFormatter;
 
     private int mGridColor = Color.GRAY;
 
@@ -552,6 +555,18 @@ public abstract class AxisBase extends ComponentBase {
             mAxisValueFormatter = new DefaultAxisValueFormatter(mDecimals);
 
         return mAxisValueFormatter;
+    }
+
+
+    public void setAxisLabelStyleFormatter(IAxisStyleFormatter f) {
+        mAxisLabelStyleFormatter = f;
+    }
+
+    public IAxisStyleFormatter getAxisLabelStyleFormatter() {
+        // return null if not set
+        if(mAxisLabelStyleFormatter == null)
+            return null;
+        return mAxisLabelStyleFormatter;
     }
 
     /**

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/IAxisStyleFormatter.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/formatter/IAxisStyleFormatter.java
@@ -1,0 +1,30 @@
+package com.github.mikephil.charting.formatter;
+
+import android.graphics.Typeface;
+
+import com.github.mikephil.charting.components.AxisBase;
+
+public interface IAxisStyleFormatter {
+    /**
+     * Called when a value from an axis is to be formatted visually ( typeface, textSize, color, etc. ).
+     * before being drawn. For performance reasons, avoid excessive calculations
+     * and memory allocations inside this method.
+     *
+     * @param value the value to be formatted
+     * @param axis  the axis the value belongs to
+     * @return
+     */
+    Typeface getTypefaceForAxisValue(float value, AxisBase axis);
+
+    /**
+     * Called when a value from an axis is to be formatted visually ( typeface, textSize, color, etc. ).
+     * before being drawn. For performance reasons, avoid excessive calculations
+     * and memory allocations inside this method.
+     *
+     * @param value the value to be formatted
+     * @param axis  the axis the value belongs to
+     * @return
+     */
+    int getTextColorForAxisValue(float value, AxisBase axis);
+}
+

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -7,10 +7,12 @@ import android.graphics.Paint;
 import android.graphics.Paint.Align;
 import android.graphics.Path;
 import android.graphics.RectF;
+import android.graphics.Typeface;
 
 import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.XAxis.XAxisPosition;
+import com.github.mikephil.charting.formatter.IAxisStyleFormatter;
 import com.github.mikephil.charting.utils.FSize;
 import com.github.mikephil.charting.utils.MPPointD;
 import com.github.mikephil.charting.utils.MPPointF;
@@ -204,6 +206,23 @@ public class XAxisRenderer extends AxisRenderer {
 
                 String label = mXAxis.getValueFormatter().getFormattedValue(mXAxis.mEntries[i / 2], mXAxis);
 
+                // get the custom axis label style formatter if set
+                IAxisStyleFormatter axisLabelStyleFormatter = mXAxis.getAxisLabelStyleFormatter();
+
+                if(axisLabelStyleFormatter != null) {
+                    // get label Text Style
+                    Typeface tf = axisLabelStyleFormatter.getTypefaceForAxisValue( mXAxis.mEntries[i / 2], mXAxis);
+                    if (tf != null) {
+                        mAxisLabelPaint.setTypeface(tf);
+                    }
+
+                    // get label text color
+                    int color = axisLabelStyleFormatter.getTextColorForAxisValue( mXAxis.mEntries[i / 2], mXAxis);
+                    if (color != 0) {
+                        mAxisLabelPaint.setColor(color);
+                    }
+                }
+
                 if (mXAxis.isAvoidFirstLastClippingEnabled()) {
 
                     // avoid clipping of the last
@@ -228,6 +247,10 @@ public class XAxisRenderer extends AxisRenderer {
     }
 
     protected void drawLabel(Canvas c, String formattedLabel, float x, float y, MPPointF anchor, float angleDegrees) {
+        Utils.drawXAxisValue(c, formattedLabel, x, y, mAxisLabelPaint, anchor, angleDegrees);
+    }
+
+    protected void drawLabelWithFormatting(Canvas c, String formattedLabel, float x, float y, MPPointF anchor, float angleDegrees) {
         Utils.drawXAxisValue(c, formattedLabel, x, y, mAxisLabelPaint, anchor, angleDegrees);
     }
     protected Path mRenderGridLinesPath = new Path();

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -249,10 +249,6 @@ public class XAxisRenderer extends AxisRenderer {
     protected void drawLabel(Canvas c, String formattedLabel, float x, float y, MPPointF anchor, float angleDegrees) {
         Utils.drawXAxisValue(c, formattedLabel, x, y, mAxisLabelPaint, anchor, angleDegrees);
     }
-
-    protected void drawLabelWithFormatting(Canvas c, String formattedLabel, float x, float y, MPPointF anchor, float angleDegrees) {
-        Utils.drawXAxisValue(c, formattedLabel, x, y, mAxisLabelPaint, anchor, angleDegrees);
-    }
     protected Path mRenderGridLinesPath = new Path();
     protected float[] mRenderGridLinesBuffer = new float[2];
     @Override

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,10 @@ include 'MPChartLib'
 include 'MPChartExample'
 //include ':MPChartLib-Realm'
 //project(':MPChartLib-Realm').projectDir = new File('../MPAndroidChart-Realm/MPChartLib-Realm')
+include ':MPChartLib'
+include ':MPChartExample'
+project(':MPAndroidChart/MPChartLib').projectDir = new File(rootDir, 'MPAndroidChart/MPChartLib/')
+project(':MPAndroidChart/MPChartExample').projectDir = new File(rootDir, 'MPAndroidChart/MPChartExample/')
+
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,10 +3,6 @@ include 'MPChartLib'
 include 'MPChartExample'
 //include ':MPChartLib-Realm'
 //project(':MPChartLib-Realm').projectDir = new File('../MPAndroidChart-Realm/MPChartLib-Realm')
-include ':MPChartLib'
-include ':MPChartExample'
-project(':MPAndroidChart/MPChartLib').projectDir = new File(rootDir, 'MPAndroidChart/MPChartLib/')
-project(':MPAndroidChart/MPChartExample').projectDir = new File(rootDir, 'MPAndroidChart/MPChartExample/')
 
 
 


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [x] I have added/updated examples and tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]
       <!-- If you'd like to suggest a significant change, please
            create an issue to discuss those changes and gather
            feedback BEFORE submitting your PR. -->


## PR Description
<!-- Describe Your PR Here! -->
This PR adds a custom axis label style formatter for `BaseAxis`. The interface `IAxisStyleFormatter` can be used to define per index value styling ( textColor, typeFace, etc ) for the axis labels.
<!-- What does this add/ remove/ fix/ change? -->

<!-- WHY should this PR be merged into the main library? -->
