### PR TITLE
fix: memory leak

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedMoveViewJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/AnimatedMoveViewJob.java
@@ -36,6 +36,15 @@ public class AnimatedMoveViewJob extends AnimatedViewPortJob {
     }
 
     public static void recycleInstance(AnimatedMoveViewJob instance){
+        // Clear reference avoid memory leak
+        instance.mViewPortHandler = null;
+        instance.xValue = 0f;
+        instance.yValue = 0f;
+        instance.mTrans = null;
+        instance.view = null;
+        instance.xOrigin = 0f;
+        instance.yOrigin = 0f;
+        instance.animator.setDuration(0);
         pool.recycle(instance);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/MoveViewJob.java
@@ -29,7 +29,13 @@ public class MoveViewJob extends ViewPortJob {
         return result;
     }
 
-    public static void recycleInstance(MoveViewJob instance){
+    public static void recycleInstance(MoveViewJob instance) {
+        // Clear reference avoid memory leak
+        instance.mViewPortHandler = null;
+        instance.xValue = 0f;
+        instance.yValue = 0f;
+        instance.mTrans = null;
+        instance.view = null;
         pool.recycle(instance);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/ZoomJob.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/jobs/ZoomJob.java
@@ -37,6 +37,15 @@ public class ZoomJob extends ViewPortJob {
     }
 
     public static void recycleInstance(ZoomJob instance) {
+        // Clear reference avoid memory leak
+        instance.xValue = 0f;
+        instance.yValue = 0f;
+        instance.scaleX = 0f;
+        instance.scaleY = 0f;
+        instance.mViewPortHandler = null;
+        instance.mTrans = null;
+        instance.axisDependency = null;
+        instance.view = null;
         pool.recycle(instance);
     }
 

--- a/MPChartLib/src/main/java/com/github/mikephil/charting/utils/ObjectPool.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/utils/ObjectPool.java
@@ -117,6 +117,7 @@ public class ObjectPool<T extends ObjectPool.Poolable> {
         }
 
         T result = (T)objects[this.objectsPointer];
+        objects[this.objectsPointer] = null;
         result.currentOwnerId = Poolable.NO_OWNER;
         this.objectsPointer--;
 


### PR DESCRIPTION
ObjectPool cache some Poolable Objects, but some Poolable Object reference to View
Object, and View Object reference to Context Object, And ObjectPool is static, so leak Context. For example, ObjectPool.objects ---> AnimatedMoveViewJob.view ---> View.mContext ---> Context

Clear Poolable Object fields when Poolable Object is recycled.